### PR TITLE
Added in onBlur prop for custom onBlur functionality

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -44,6 +44,7 @@ var classBase = React.createClass({
     typeaheadDelay: React.PropTypes.number,
     showCurrentOptionWhenOpen: React.PropTypes.bool,
     onChange: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     // Should there just be a baseClassName that these are derived from?
     className: React.PropTypes.string,
     openClassName: React.PropTypes.string,
@@ -197,6 +198,10 @@ var classBase = React.createClass({
     });
   },
   onBlur () {
+    if (this.props.onBlur) {
+      this.props.onBlur();
+    }
+
     this.setState({
       focus: false
     });

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -199,9 +199,13 @@ var classBase = React.createClass({
     });
   },
   onBlur () {
+    var self = this;
+
     this.setState({
       focus: false
-    }, this.props.onBlur);
+    }, function () {
+      self.props.onBlur();
+    });
   },
   // Arrow keys are only captured by onKeyDown not onKeyPress
   // http://stackoverflow.com/questions/5597060/detecting-arrow-key-presses-in-javascript

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -199,13 +199,9 @@ var classBase = React.createClass({
     });
   },
   onBlur () {
-    var self = this;
-
     this.setState({
       focus: false
-    }, function () {
-      self.props.onBlur();
-    });
+    }, () => { this.props.onBlur(); });
   },
   // Arrow keys are only captured by onKeyDown not onKeyPress
   // http://stackoverflow.com/questions/5597060/detecting-arrow-key-presses-in-javascript

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -60,6 +60,7 @@ var classBase = React.createClass({
       typeaheadDelay: 1000,
       showCurrentOptionWhenOpen: false,
       onChange: function () {},
+      onBlur: function () {},
       className: 'radon-select',
       openClassName: 'open',
       focusClassName: 'focus',
@@ -198,13 +199,9 @@ var classBase = React.createClass({
     });
   },
   onBlur () {
-    if (this.props.onBlur) {
-      this.props.onBlur();
-    }
-
     this.setState({
       focus: false
-    });
+    }, this.props.onBlur);
   },
   // Arrow keys are only captured by onKeyDown not onKeyPress
   // http://stackoverflow.com/questions/5597060/detecting-arrow-key-presses-in-javascript


### PR DESCRIPTION
Added in the option to provide a custom onBlur function as a prop. I added it in to radon-select's onBlur existing onBlur function so that it does not prevent any existing functionality.