### PR TITLE
I o stouch event workaround

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -3,6 +3,8 @@ var React = require('react');
 var cloneWithProps = require('react/lib/cloneWithProps');
 var assign = require('object-assign');
 
+React.initializeTouchEvents(true);
+
 var keyboard = {
   space: 32,
   enter: 13,
@@ -385,6 +387,11 @@ classBase.Option = React.createClass({
         role: "button", 
         className: this.getClassNames(), 
         tabIndex: -1, 
+
+        // This is a workaround for a long-standing iOS/React issue with click events.
+        // See https://github.com/facebook/react/issues/134 for more information.
+        onTouchStart: this.props.onClick, 
+
         onMouseDown: this.props.onClick, 
         onMouseEnter: this.setHover.bind(this, true), 
         onMouseLeave: this.setHover.bind(this, false), 

--- a/lib/select.js
+++ b/lib/select.js
@@ -44,6 +44,7 @@ var classBase = React.createClass({
     typeaheadDelay: React.PropTypes.number,
     showCurrentOptionWhenOpen: React.PropTypes.bool,
     onChange: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     // Should there just be a baseClassName that these are derived from?
     className: React.PropTypes.string,
     openClassName: React.PropTypes.string,
@@ -59,6 +60,7 @@ var classBase = React.createClass({
       typeaheadDelay: 1000,
       showCurrentOptionWhenOpen: false,
       onChange: function () {},
+      onBlur: function () {},
       className: 'radon-select',
       openClassName: 'open',
       focusClassName: 'focus',
@@ -199,7 +201,7 @@ var classBase = React.createClass({
   onBlur:function () {
     this.setState({
       focus: false
-    });
+    }, function()  { this.props.onBlur(); }.bind(this));
   },
   // Arrow keys are only captured by onKeyDown not onKeyPress
   // http://stackoverflow.com/questions/5597060/detecting-arrow-key-presses-in-javascript
@@ -234,8 +236,9 @@ var classBase = React.createClass({
     }
   },
   onClickOption:function (index, ev) {
-    ev.preventDefault();
     var child = this.refs['option' + index];
+
+    ev.preventDefault();
 
     this.setState({
       selectedOptionIndex: index,

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -3,6 +3,8 @@ var React = require('react');
 var cloneWithProps = require('react/lib/cloneWithProps');
 var assign = require('object-assign');
 
+React.initializeTouchEvents(true);
+
 var keyboard = {
   space: 32,
   enter: 13,
@@ -385,6 +387,11 @@ classBase.Option = React.createClass({
         role='button'
         className={this.getClassNames()}
         tabIndex={-1}
+
+        // This is a workaround for a long-standing iOS/React issue with click events.
+        // See https://github.com/facebook/react/issues/134 for more information.
+        onTouchStart={this.props.onClick}
+
         onMouseDown={this.props.onClick}
         onMouseEnter={this.setHover.bind(this, true)}
         onMouseLeave={this.setHover.bind(this, false)}


### PR DESCRIPTION
As discussed with @kenwheeler this is probably the best current workaround for what seems to be a long-standing iOS/React bug/quirk.

See more:
http://stackoverflow.com/questions/5421659/html-label-command-doesnt-work-in-iphone-browser/6472181#6472181
https://github.com/facebook/react/issues/134
https://github.com/facebook/react/issues/1169