### PR TITLE
Removes react peer dependency, changes devDependency to 0.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   },
   "author": "",
   "license": "MIT",
-  "peerDependencies": {
-    "react": ">=0.12.0 <0.14.0"
-  },
   "devDependencies": {
     "babel-eslint": "^2.0.2",
     "babel-loader": "^4.3.0",
@@ -35,7 +32,7 @@
     "karma-sinon-chai": "^0.3.0",
     "karma-webpack": "^1.5.0",
     "mocha": "^2.2.1",
-    "react": ">=0.12.0 <0.14.0",
+    "react": "^0.13.3",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "webpack": "^1.5.3",


### PR DESCRIPTION
There's something really wonky about `peerDependencies` that can cause some weird `react` conflicts when the amount of packages being used grows. Removing `peerDependencies` for `react` should help fix that.