### PR TITLE
Introduce automation id support, with auto-gen for child options

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -278,7 +278,8 @@ var classBase = React.createClass({
       ref: 'option' + index,
       isActive: this.state.selectedOptionIndex === index,
       onClick: this.onClickOption.bind(this, index),
-      onKeyDown: this.onKeyDown
+      onKeyDown: this.onKeyDown,
+      automationId: (this.props.automationId ? this.props.automationId : 'select') + '-option-' + index
     });
   },
   renderSpacerChild (child, index) {
@@ -305,6 +306,7 @@ var classBase = React.createClass({
             ref='currentOption'
             className={this.props.currentOptionClassName}
             tabIndex={0}
+            data-automation-id={this.props.automationId}
             role='button'
             onFocus={this.onFocus}
             onKeyDown={this.onKeyDown}
@@ -344,11 +346,13 @@ classBase.Option = React.createClass({
     // TODO: Disabled
     value: React.PropTypes.string.isRequired,
     children: React.PropTypes.string.isRequired,
-    onClick: React.PropTypes.func
+    onClick: React.PropTypes.func,
+    automationId: React.PropTypes.string
   },
   getDefaultProps () {
     return {
       value: '',
+      automationId: undefined,
       className: 'radon-select-option',
       activeClassName: 'active',
       hoverClassName: 'hover',
@@ -391,6 +395,7 @@ classBase.Option = React.createClass({
       <div
         role='button'
         className={this.getClassNames()}
+        data-automation-id={this.props.automationId}
         tabIndex={-1}
 
         // This is a workaround for a long-standing iOS/React issue with click events.


### PR DESCRIPTION
This PR introduces `automationId` support.

Given a `RadonSelect` component instantiation in JSX with an `automationId` of `basicdemo`

![image](https://cloud.githubusercontent.com/assets/12995/9016923/ad717ed8-3789-11e5-9bde-1dda382494af.png)

The following is rendered as a result:

Representative selection element *before* clicking:

![image](https://cloud.githubusercontent.com/assets/12995/9016865/25e4ffbc-3789-11e5-9075-3aece0a4b64e.png)

Child options after clicking, with `basicdemo` inherited as a prefix from the select component (note the indexing):

![image](https://cloud.githubusercontent.com/assets/12995/9016882/4c6036ac-3789-11e5-9175-4833729dba5c.png)

RadonSelect components without an `automationId` set have no default `data-automation-id`. Only child options are given automatically-generated automation ids, which default to `select-option-N` in the absence of a human-set `automationId`.

/cc @rgerstenberger @alexlande 