### PR TITLE
Bumped babel-core to 5.x and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radon-select",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React select box replacement component",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "babel": "^5.6.14",
-    "babel-core": "^4.7.16",
+    "babel-core": "^5.1.13",
     "object-assign": "^2.0.0",
     "rimraf": "^2.4.1"
   }


### PR DESCRIPTION
Some things changed in Babel between 4.x and 5.x this is to help bring all our dependancies up and hopefully work on IE-8