### PR TITLE
Change findDOMNode to come from react-dom

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -16,7 +16,7 @@ var App = React.createClass({
   },
   setCarValue(ev) {
     ev.preventDefault();
-    this.refs.car.setValue(React.findDOMNode(this.refs.newCar).value.trim());
+    this.refs.car.setValue(ReactDOM.findDOMNode(this.refs.newCar).value.trim());
   },
   render() {
     return (

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var ReactDOM = require('react-dom');
 var assign = require('object-assign');
 
 var keyboard = {
@@ -117,7 +118,7 @@ var classBase = React.createClass({
 
       if (this.state.open) {
         this.isFocusing = true;
-        React.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
+        ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
       }
     });
   },
@@ -163,7 +164,7 @@ var classBase = React.createClass({
 
         if (this.state.open) {
           this.isFocusing = true;
-          React.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
+          ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
         }
       });
     }
@@ -184,9 +185,9 @@ var classBase = React.createClass({
       this.onChange();
 
       if (!this.state.open) {
-        React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
+        ReactDOM.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
       } else {
-          React.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
+          ReactDOM.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
         }
     });
   },
@@ -244,7 +245,7 @@ var classBase = React.createClass({
     }, function () {
       this.onChange();
 
-      React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
+      ReactDOM.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
     });
   },
   onBlurOption: function onBlurOption(ev) {
@@ -255,7 +256,7 @@ var classBase = React.createClass({
       return;
     }
 
-    var hoveredSelectEl = React.findDOMNode(this).querySelector(':hover');
+    var hoveredSelectEl = ReactDOM.findDOMNode(this).querySelector(':hover');
     // Clicks on the scrollbar trigger blur, only test is hover.
     // If the mouse is over the select, don't close the option list
     if (hoveredSelectEl) {

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react');
+var ReactDOM = require('react-dom');
 var assign = require('object-assign');
 
 var keyboard = {
@@ -118,7 +119,7 @@ var classBase = React.createClass({
 
       if (this.state.open) {
         this.isFocusing = true;
-        React.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
+        ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
       }
     });
   },
@@ -165,7 +166,7 @@ var classBase = React.createClass({
 
         if (this.state.open) {
           this.isFocusing = true;
-          React.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
+          ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
         }
       });
     }
@@ -186,9 +187,9 @@ var classBase = React.createClass({
       this.onChange();
 
       if (!this.state.open) {
-        React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
+        ReactDOM.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
       } else {
-        React.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
+        ReactDOM.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
       }
     });
   },
@@ -246,7 +247,7 @@ var classBase = React.createClass({
     }, function () {
       this.onChange();
 
-      React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
+      ReactDOM.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
     });
   },
   onBlurOption (ev) {
@@ -257,7 +258,7 @@ var classBase = React.createClass({
       return;
     }
 
-    var hoveredSelectEl = React.findDOMNode(this).querySelector(':hover');
+    var hoveredSelectEl = ReactDOM.findDOMNode(this).querySelector(':hover');
     // Clicks on the scrollbar trigger blur, only test is hover.
     // If the mouse is over the select, don't close the option list
     if (hoveredSelectEl) {


### PR DESCRIPTION
There's a warning for `findDOMNode` that it should come from `react-dom`. This doesn't _really_ impact consumers with the exception that they will get a red herring that they'll probably try and figure out where this warning is coming from and take a while to find out it comes from here.

cc @kenwheeler @rgerstenberger 