### PR TITLE
Add empty onChange to supress console warning.

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -247,7 +247,7 @@ var classBase = React.createClass({
       React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
     });
   },
-  onBlurOption: function onBlurOption(ev) {
+  onBlurOption: function onBlurOption() {
     // Make sure we only catch blur that wasn't triggered by this component
     if (this.isFocusing) {
       this.isFocusing = false;
@@ -341,7 +341,7 @@ var classBase = React.createClass({
       ) : '',
       React.createElement(
         'select',
-        { name: this.props.selectName, value: this.state.selectedOptionVal, className: this.props.hiddenSelectClassName, tabIndex: -1, 'aria-hidden': true },
+        { name: this.props.selectName, onChange: function () {}, value: this.state.selectedOptionVal, className: this.props.hiddenSelectClassName, tabIndex: -1, 'aria-hidden': true },
         React.Children.map(this.props.children, function (child, index) {
           return React.createElement(
             'option',

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -249,7 +249,7 @@ var classBase = React.createClass({
       React.findDOMNode(this.refs['currentOption']).focus(); //eslint-disable-line dot-notation
     });
   },
-  onBlurOption (ev) {
+  onBlurOption () {
     // Make sure we only catch blur that wasn't triggered by this component
     if (this.isFocusing) {
       this.isFocusing = false;
@@ -344,7 +344,7 @@ var classBase = React.createClass({
           </div>
           : ''
         }
-        <select name={this.props.selectName} value={this.state.selectedOptionVal} className={this.props.hiddenSelectClassName} tabIndex={-1} aria-hidden={true} >
+        <select name={this.props.selectName} onChange={() => {}} value={this.state.selectedOptionVal} className={this.props.hiddenSelectClassName} tabIndex={-1} aria-hidden={true} >
           {React.Children.map(this.props.children, function (child, index) {
             return <option key={index} value={child.props.value}>{child.props.children}</option>
           })}


### PR DESCRIPTION
Chooser (and anything that used it) is getting this nasty warning:

```
Warning: Failed form propType: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`. Check the render method of `RadonSelect`.
```

Pinned it down to the <select/> in this lib that needed `onChange: function () {}` to suppress the warning. Per [https://github.com/facebook/react/issues/1118#issuecomment-36658165](https://github.com/facebook/react/issues/1118#issuecomment-36658165)

Also, removed an unused `ev` to picked up by the linter.

@kenwheeler @rgerstenberger 