### PR TITLE
Wrap in ReactDOM.findDOMNode() to silence error when node is null.

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -118,7 +118,7 @@ var classBase = React.createClass({
 
       if (this.state.open) {
         this.isFocusing = true;
-        this.refs['option' + this.state.selectedOptionIndex].focus();
+        this.focus(this.refs['option' + this.state.selectedOptionIndex]);
       }
     });
   },
@@ -185,9 +185,9 @@ var classBase = React.createClass({
       this.onChange();
 
       if (!this.state.open) {
-        this.refs['currentOption'].focus(); //eslint-disable-line dot-notation
+        this.focus(this.refs['currentOption']); //eslint-disable-line dot-notation
       } else {
-          ReactDOM.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
+          this.focus(this.refs['option' + (this.state.selectedOptionIndex || 0)]);
         }
     });
   },
@@ -283,6 +283,9 @@ var classBase = React.createClass({
     }
 
     return wrapperClassNames.join(' ');
+  },
+  focus: function focus(ref) {
+    ReactDOM.findDOMNode(ref).focus();
   },
   renderChild: function renderChild(child, index) {
     return React.cloneElement(child, {

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -119,7 +119,7 @@ var classBase = React.createClass({
 
       if (this.state.open) {
         this.isFocusing = true;
-        ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
+        this.focus(this.refs['option' + this.state.selectedOptionIndex]);
       }
     });
   },
@@ -187,9 +187,9 @@ var classBase = React.createClass({
       this.onChange();
 
       if (!this.state.open) {
-        this.refs['currentOption'].focus(); //eslint-disable-line dot-notation
+        this.focus(this.refs['currentOption']); //eslint-disable-line dot-notation
       } else {
-        ReactDOM.findDOMNode(this.refs['option' + (this.state.selectedOptionIndex || 0)]).focus();
+        this.focus(this.refs['option' + (this.state.selectedOptionIndex || 0)]);
       }
     });
   },
@@ -285,6 +285,9 @@ var classBase = React.createClass({
     }
 
     return wrapperClassNames.join(' ');
+  },
+  focus(ref) {
+    ReactDOM.findDOMNode(ref).focus();
   },
   renderChild (child, index) {
     return React.cloneElement(child, {

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -119,7 +119,7 @@ var classBase = React.createClass({
 
       if (this.state.open) {
         this.isFocusing = true;
-        this.refs['option' + this.state.selectedOptionIndex].focus();
+        ReactDOM.findDOMNode(this.refs['option' + this.state.selectedOptionIndex]).focus();
       }
     });
   },


### PR DESCRIPTION
Was receiving `.focus() is not a function` at `this.refs['option' + this.state.selectedOptionIndex].focus();`. Wrapping in `ReactDOM.findDOMNode()` (similar to line 192) silenced the error.