### PR TITLE
Add support to pass ReactElement as child

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -54,6 +54,17 @@ var App = React.createClass({
         <br />
         <br />
         <h3>Get and set values</h3>
+        <RadonSelect ref="fruits" selectName="fruits" defaultValue="apple">
+          <RadonSelect.Option value="apple">
+            <h1 style={{margin:"0px"}}>apple</h1>
+          </RadonSelect.Option>
+          <RadonSelect.Option value="orange">
+            <h1 style={{margin:"0px"}}>orange</h1>
+          </RadonSelect.Option>          
+        </RadonSelect>
+        <br />
+        <br />
+        <h3>Get and set values</h3>
         <RadonSelect ref="car" selectName="car" defaultValue={this.state.carValue} onChange={this.onCarChange}>
           <RadonSelect.Option value="audi">audi</RadonSelect.Option>
           <RadonSelect.Option value="bmw">bmw</RadonSelect.Option>

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -369,8 +369,7 @@ var classBase = React.createClass({
           tabIndex={-1}
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
-              var value = child.props.value || child.props.children;
-              return <option key={index} value={child.props.value}>{value}</option>
+              return <option key={index} value={child.props.value}>{child.props.value}</option>
             })}
         </select>
         <span aria-hidden={true} style={hiddenListStyle} tabIndex={-1} >

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -387,7 +387,7 @@ classBase.Option = React.createClass({
   propTypes: {
     // TODO: Disabled
     value: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node.isRequired,
+    children: React.PropTypes.oneOfType([React.PropTypes.node, React.PropTypes.string]).isRequired,
     onClick: React.PropTypes.func,
     automationId: React.PropTypes.string
   },

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -369,7 +369,8 @@ var classBase = React.createClass({
           tabIndex={-1}
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
-              return <option key={index} value={child.props.value}>{child.props.value}</option>
+              var value = child.props.value || child.props.children;
+              return <option key={index} value={child.props.value}>{value}</option>
             })}
         </select>
         <span aria-hidden={true} style={hiddenListStyle} tabIndex={-1} >

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -369,7 +369,7 @@ var classBase = React.createClass({
           tabIndex={-1}
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
-              return <option key={index} value={child.props.value}>{child.props.children}</option>
+              return <option key={index} value={child.props.value}>{child.props.value}</option>
             })}
         </select>
         <span aria-hidden={true} style={hiddenListStyle} tabIndex={-1} >
@@ -387,7 +387,7 @@ classBase.Option = React.createClass({
   propTypes: {
     // TODO: Disabled
     value: React.PropTypes.string.isRequired,
-    children: React.PropTypes.string.isRequired,
+    children: React.PropTypes.node.isRequired,
     onClick: React.PropTypes.func,
     automationId: React.PropTypes.string
   },


### PR DESCRIPTION
- When we pass a ReactElement as a child to `RadonSelect.Option`, we see a warning in the console
`Warning: Only strings and numbers are supported as <option>`
- This is because the  `option` tag only accepts a string or number as its `children`
- This PR fixes this warning. The solution is to use the `value` property when constructing the `option's`  list with in the render function of radon select.

//cc @rgerstenberger @benbayard @exogen 