### PR TITLE
Upgrades to use Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react", "stage-0"]
+}

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,4 +1,5 @@
 'use strict';
+
 var React = require('react');
 var ReactDOM = require('react-dom');
 var assign = require('object-assign');
@@ -214,6 +215,7 @@ var classBase = React.createClass({
       _this.props.onBlur();
     });
   },
+
   // Arrow keys are only captured by onKeyDown not onKeyPress
   // http://stackoverflow.com/questions/5597060/detecting-arrow-key-presses-in-javascript
   onKeyDown: function onKeyDown(ev) {
@@ -365,7 +367,7 @@ var classBase = React.createClass({
           return React.createElement(
             'option',
             { key: index, value: child.props.value },
-            child.props.children
+            child.props.value
           );
         })
       ),
@@ -387,7 +389,7 @@ classBase.Option = React.createClass({
   propTypes: {
     // TODO: Disabled
     value: React.PropTypes.string.isRequired,
-    children: React.PropTypes.string.isRequired,
+    children: React.PropTypes.oneOfType([React.PropTypes.node, React.PropTypes.string]).isRequired,
     onClick: React.PropTypes.func,
     automationId: React.PropTypes.string
   },
@@ -440,11 +442,11 @@ classBase.Option = React.createClass({
           role: 'button',
           className: this.getClassNames(),
           'data-automation-id': this.props.automationId,
-          tabIndex: -1,
+          tabIndex: -1
 
           // This is a workaround for a long-standing iOS/React issue with click events.
           // See https://github.com/facebook/react/issues/134 for more information.
-          onTouchStart: this.tap,
+          , onTouchStart: this.tap,
 
           onMouseDown: this.props.onClick,
           onMouseEnter: this.setHover.bind(this, true),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "examples": "webpack-dev-server --config examples/webpack.config.js --no-info --content-base examples/",
-    "lib": "rimraf lib && babel --stage 0 src/ -d lib/",
+    "lib": "rimraf lib && babel src --out-dir lib",
     "lint": "eslint src/select.jsx",
     "prepublish": "npm run lib",
     "test": "karma start"
@@ -13,8 +13,12 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^2.0.2",
-    "babel-loader": "^4.3.0",
+    "babel-eslint": "^6.0.2",
+    "babel-loader": "^6.2.4",
+    "babel-cli": "^6.5.1",
+    "babel-preset-es2015": "^6.0.0",
+    "babel-preset-react": "^6.0.0",
+    "babel-preset-stage-0": "^6.0.0",
     "chai": "^2.1.2",
     "eslint": "^0.24.1",
     "eslint-plugin-react": "^2.7.0",
@@ -32,18 +36,17 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.1",
     "phantomjs": "^1.9.18",
-    "react": "^0.14.0",
+    "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react-dom": "^0.14.7",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
   },
   "dependencies": {
-    "babel": "^5.6.14",
-    "babel-core": "^4.7.16",
-    "object-assign": "^2.0.0",
+    "babel-core": "^6.7.4",
+    "object-assign": "^4.0.0",
     "rimraf": "^2.4.1"
   }
 }

--- a/test/spec/select.spec.js
+++ b/test/spec/select.spec.js
@@ -3,6 +3,7 @@
 describe('Button', function () {
 
   var React = require('react');
+  var ReactDOM = require('react-dom');
   var TestUtils = require('react-addons-test-utils');
 
   var RadonSelect = require('select.jsx');
@@ -12,7 +13,7 @@ describe('Button', function () {
 
     beforeEach(function() {
       container = document.createElement('div');
-      component = React.render(
+      component = ReactDOM.render(
         React.createElement(RadonSelect, {selectName: "test"}, [
           React.createElement(RadonSelect.Option, {key: "blah"}, "blah"),
           React.createElement(RadonSelect.Option, {key: "foo"}, "foo")
@@ -22,7 +23,7 @@ describe('Button', function () {
     });
 
     afterEach(function() {
-      React.unmountComponentAtNode(container);
+      ReactDOM.unmountComponentAtNode(container);
     });
 
     it('should render into the document', function() {


### PR DESCRIPTION
Using `radon-select` in a project that uses babel 6 results in issues as it was still using an older version of babel. This brings the newer babel in to play.