### PR TITLE
Add null safety to prevent iOS selection bug.

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -247,7 +247,8 @@ var classBase = React.createClass({
   onClickOption: function onClickOption(index, ev) {
     var child = this.refs['option' + index];
 
-    ev.preventDefault();
+    // Null safety here prevents an iOS-specific bug preventing selection of options
+    ev ? ev.preventDefault() : null;
 
     this.setState({
       selectedOptionIndex: index,

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -251,7 +251,8 @@ var classBase = React.createClass({
   onClickOption (index, ev) {
     var child = this.refs['option' + index];
 
-    ev.preventDefault();
+    // Null safety here prevents an iOS-specific bug preventing selection of options
+    ev ? ev.preventDefault() : null;
 
     this.setState({
       selectedOptionIndex: index,


### PR DESCRIPTION
Prevents iOS from throwing `ev.preventDefault() is not a function` and impeding use of the dropdown box. @rgerstenberger @Maciek416 