### PR TITLE
[MINOR] Upgrade object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "babel-core": "^6.7.4",
-    "object-assign": "^4.0.0",
+    "object-assign": "^4.1.0",
     "rimraf": "^2.4.1"
   }
 }


### PR DESCRIPTION
This PR upgrades `object-select` to `4.1.0`, the latest version.