### PR TITLE
[Minor] Adding componentWillReceieveProps function

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -2,6 +2,50 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var RadonSelect = require('../src/select.jsx');
 
+var StatefulRadonSelect = React.createClass({
+  getInitialState() {
+    return {
+      cityCode: "SF",
+      cityName: "San Fransisco"
+    }
+  },
+  changeCity(ev) {
+    this.setState({
+      cityCode: ev.target.dataset.city,
+      cityName: ev.target.dataset.name
+    });
+  },
+  onCityChange(val) {
+    var name = val === "KC"
+      ? "Kansas City"
+      : "San Fransisco";
+
+    this.setState({
+      cityCode: val,
+      cityName: name
+    });
+  },
+  render() {
+    return (
+      <div>
+        <RadonSelect
+          selectName={this.state.cityName}
+          defaultValue={this.state.cityCode}
+          onChange={this.onCityChange}>
+          <RadonSelect.Option value="SF">San Fransisco</RadonSelect.Option>
+          <RadonSelect.Option value="KC">Kansas City</RadonSelect.Option>
+        </RadonSelect>
+        <button data-city="SF" data-name="San Fransisco" onClick={this.changeCity}>
+          Set San Fransisco
+        </button>
+        <button data-city="KC" data-name="Kansas City" onClick={this.changeCity}>
+          Set Kansas City
+        </button>
+      </div>
+    );
+  }
+});
+
 var App = React.createClass({
   displayName: "App",
   getInitialState() {
@@ -60,7 +104,7 @@ var App = React.createClass({
           </RadonSelect.Option>
           <RadonSelect.Option value="orange">
             <h1 style={{margin:"0px"}}>orange</h1>
-          </RadonSelect.Option>          
+          </RadonSelect.Option>
         </RadonSelect>
         <br />
         <br />
@@ -81,6 +125,8 @@ var App = React.createClass({
             <button type="submit">set</button>
           </form>
         </span>
+        <h3>Get and Set  Values passed as props from parent</h3>
+        <StatefulRadonSelect/>
       </div>
     );
   }

--- a/lib/select.js
+++ b/lib/select.js
@@ -20,7 +20,7 @@ var doesOptionMatch = function doesOptionMatch(option, s) {
   if (typeof option.props.children === 'string') {
     return option.props.children.toLowerCase().indexOf(s) === 0;
   } else {
-    return option.props.value.tolowerCase().indexOf(s) === 0;
+    return option.props.value.toLowerCase().indexOf(s) === 0;
   }
 };
 
@@ -205,8 +205,8 @@ var classBase = React.createClass({
       if (!this.state.open) {
         this.focus(this.refs['currentOption']); //eslint-disable-line dot-notation
       } else {
-          this.focus(this.refs['option' + (this.state.selectedOptionIndex || 0)]);
-        }
+        this.focus(this.refs['option' + (this.state.selectedOptionIndex || 0)]);
+      }
     });
   },
   onFocus: function onFocus() {
@@ -240,16 +240,16 @@ var classBase = React.createClass({
         this.moveIndexByOne( /*decrement*/ev.keyCode === keyboard.upArrow);
         // If not tab, assume alphanumeric
       } else if (ev.keyCode !== keyboard.tab) {
-          this.typeahead(String.fromCharCode(ev.keyCode));
-        }
+        this.typeahead(String.fromCharCode(ev.keyCode));
+      }
     } else {
       if (ev.keyCode === keyboard.space || isArrowKey) {
         ev.preventDefault();
         this.toggleOpen();
         // If not tab, escape, or enter, assume alphanumeric
       } else if (ev.keyCode !== keyboard.enter || ev.keyCode !== keyboard.escape || ev.keyCode !== keyboard.tab) {
-          this.typeahead(String.fromCharCode(ev.keyCode));
-        }
+        this.typeahead(String.fromCharCode(ev.keyCode));
+      }
     }
   },
   onClickOption: function onClickOption(index, ev) {
@@ -439,14 +439,8 @@ classBase.Option = React.createClass({
       hovered: isHover
     });
   },
-  tap: function tap() {
-    // Call onClick indirectly so that React's Synthetic Touch Event doesn't propagate.
-    // The resulting behavior should be that an options dropdown list can be scrolled
-    // and only selects an option when a user has tapped an option without dragging the parent.
-    this.props.onClick();
-  },
   render: function render() {
-    return(
+    return (
       // Safari ignores tabindex on buttons, and Firefox ignores tabindex on anchors
       // use a <div role="button">.
       React.createElement(
@@ -455,12 +449,7 @@ classBase.Option = React.createClass({
           role: 'button',
           className: this.getClassNames(),
           'data-automation-id': this.props.automationId,
-          tabIndex: -1
-
-          // This is a workaround for a long-standing iOS/React issue with click events.
-          // See https://github.com/facebook/react/issues/134 for more information.
-          , onTouchStart: this.tap,
-
+          tabIndex: -1,
           onMouseDown: this.props.onClick,
           onMouseEnter: this.setHover.bind(this, true),
           onMouseLeave: this.setHover.bind(this, false),

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -74,10 +74,13 @@ var classBase = React.createClass({
       optionListStyle: {}
     };
   },
-  getInitialState () {
-    var initialIndex = this.props.defaultValue !== undefined
-      ? this.getValueIndex(this.props.defaultValue)
+  _getInitialIndex(defaultValue) {
+    return defaultValue !== undefined
+      ? this.getValueIndex(defaultValue)
       : -1;
+  },
+  getInitialState () {
+    var initialIndex = this._getInitialIndex(this.props.defaultValue);
 
     var defaultValue = initialIndex === -1
       ? this.props.children[0].props.value
@@ -89,6 +92,15 @@ var classBase = React.createClass({
       open: false,
       focus: false
     };
+  },
+  componentWillReceiveProps(nextProps) {
+    if(nextProps && this.props && nextProps.defaultValue !== this.props.defaultValue) {
+      var initialIndex =this._getInitialIndex(nextProps.defaultValue);
+      this.setState({
+        selectedOptionVal: nextProps.defaultValue,
+        selectedOptionIndex: initialIndex
+      })
+    }
   },
   getValueIndex (val) {
     for (var i = 0; i < this.props.children.length; ++i) {


### PR DESCRIPTION
### Summary
- When the defaultValue for the radon select is passed via a prop into radon-select from a higher-order parent component, radon-select does not reflect this changes.
- This was because, the internal state of radon-select was never re-set.
- This PR fixes that by adding a `componetWillReceieveProps` to update the internalState when defaultValue changes
- Also added a simple example to illustrate this in demo page

### Screenshot

Before | After 
---|---
![radon-select-bug](https://cloud.githubusercontent.com/assets/1467801/20077908/323b4176-a4f3-11e6-81b8-4bd16e33bd77.gif) | ![radon-select-fix](https://cloud.githubusercontent.com/assets/1467801/20077913/36e41bbc-a4f3-11e6-9b49-f1c241505659.gif)


//cc @rgerstenberger  @exogen @kenwheeler 