### PR TITLE
ADA Compliant attribute to form field

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -39,6 +39,7 @@ var classBase = React.createClass({
     },
     selectName: React.PropTypes.string.isRequired,
     defaultValue: React.PropTypes.string,
+    areaLabel: React.PropTypes.string,
     placeholderText: React.PropTypes.string,
     typeaheadDelay: React.PropTypes.number,
     showCurrentOptionWhenOpen: React.PropTypes.bool,
@@ -380,6 +381,7 @@ var classBase = React.createClass({
           value={this.state.selectedOptionVal}
           className={this.props.hiddenSelectClassName}
           tabIndex={-1}
+          aria-label={this.props.areaLabel ? this.props.areaLabel : this.props.selectName }
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
               return <option key={index} value={child.props.value}>{child.props.value}</option>

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -39,7 +39,7 @@ var classBase = React.createClass({
     },
     selectName: React.PropTypes.string.isRequired,
     defaultValue: React.PropTypes.string,
-    areaLabel: React.PropTypes.string,
+    ariaLabel: React.PropTypes.string,
     placeholderText: React.PropTypes.string,
     typeaheadDelay: React.PropTypes.number,
     showCurrentOptionWhenOpen: React.PropTypes.bool,
@@ -381,7 +381,7 @@ var classBase = React.createClass({
           value={this.state.selectedOptionVal}
           className={this.props.hiddenSelectClassName}
           tabIndex={-1}
-          aria-label={this.props.areaLabel ? this.props.areaLabel : this.props.selectName }
+          aria-label={this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName }
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
               return <option key={index} value={child.props.value}>{child.props.value}</option>


### PR DESCRIPTION
### Summary
 - The select form field has to have the ADA compliant label which basically explained at least what the selector are for.
 - As this will be used at some critical part of component e.g. selecting size, quantity, types or more which is probably required to move forward with form submission, I have added `areaLabel` prop to pass to `<select>` element.
 - This PR will remedy very critical ADA compliant Principal. also will help when it was used without label element.

/cc @exogen @jherr 