### PR TITLE
ADA Keyboard Accessibility: Add prop to disable auto refresh for keyboard navigating

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -135,7 +135,7 @@ var classBase = React.createClass({
       selectedOptionIndex: selectedOptionIndex,
       selectedOptionVal: this.props.children[selectedOptionIndex].props.value
     }, function () {
-      if (!this.props.disableAutoRefresh) {
+      if (!this.props.disableUpDownAutoRefresh) {
         this.onChange();
       }
 

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -55,7 +55,8 @@ var classBase = React.createClass({
     currentOptionClassName: React.PropTypes.string,
     hiddenSelectClassName: React.PropTypes.string,
     currentOptionStyle: React.PropTypes.object,
-    optionListStyle: React.PropTypes.object
+    optionListStyle: React.PropTypes.object,
+    disableAutoRefresh: React.PropTypes.bool
   },
   getDefaultProps () {
     return {
@@ -72,7 +73,8 @@ var classBase = React.createClass({
       hiddenSelectClassName: 'radon-select-hidden-select',
       disabledClassName: 'radon-select-disabled',
       currentOptionStyle: {},
-      optionListStyle: {}
+      optionListStyle: {},
+      disableAutoRefresh: false
     };
   },
   getInitialState () {
@@ -133,7 +135,9 @@ var classBase = React.createClass({
       selectedOptionIndex: selectedOptionIndex,
       selectedOptionVal: this.props.children[selectedOptionIndex].props.value
     }, function () {
-      this.onChange();
+      if (!this.props.disableAutoRefresh) {
+        this.onChange();
+      }
 
       if (this.state.open) {
         this.isFocusing = true;

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -56,7 +56,7 @@ var classBase = React.createClass({
     hiddenSelectClassName: React.PropTypes.string,
     currentOptionStyle: React.PropTypes.object,
     optionListStyle: React.PropTypes.object,
-    disableAutoRefresh: React.PropTypes.bool
+    disableUpDownAutoRefresh: React.PropTypes.bool
   },
   getDefaultProps () {
     return {
@@ -74,7 +74,7 @@ var classBase = React.createClass({
       disabledClassName: 'radon-select-disabled',
       currentOptionStyle: {},
       optionListStyle: {},
-      disableAutoRefresh: false
+      disableUpDownAutoRefresh: false
     };
   },
   getInitialState () {


### PR DESCRIPTION
## Summary:

This pr solves auto refresh issue for keyboard navigating through sort refine menu on search&browse page when using up and down arrow key. This is fixed by adding a flag to disable onChange() function getting fired when moving between options. he pr is a combination with https://gecgithub01.walmart.com/react/search-util-bar/pull/78 and https://gecgithub01.walmart.com/react/chooser/pull/70


## Screen Recording:

Before fix:
![sortmenu_before](https://cloud.githubusercontent.com/assets/5570506/21739200/6c35fbc0-d449-11e6-8b98-8e8b901f993b.gif)


After fix:
![sortmenu_after](https://cloud.githubusercontent.com/assets/5570506/21739201/729814da-d449-11e6-9dae-a5407dc27832.gif)




