### PR TITLE
Add verbose aria labeling

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -13,6 +13,11 @@ var keyboard = {
   downArrow: 40
 };
 
+// Nessesary as div(role=button) does not report value or aria-valuetext to the screenreader
+var generateAriaLabel = function generateAriaLabel(label, value) {
+  return label + ' ' + value;
+};
+
 var doesOptionMatch = function doesOptionMatch(option, s) {
   s = s.toLowerCase();
 
@@ -56,7 +61,8 @@ var classBase = React.createClass({
     currentOptionClassName: React.PropTypes.string,
     hiddenSelectClassName: React.PropTypes.string,
     currentOptionStyle: React.PropTypes.object,
-    optionListStyle: React.PropTypes.object
+    optionListStyle: React.PropTypes.object,
+    disableUpDownAutoRefresh: React.PropTypes.bool
   },
   getDefaultProps: function getDefaultProps() {
     return {
@@ -73,7 +79,8 @@ var classBase = React.createClass({
       hiddenSelectClassName: 'radon-select-hidden-select',
       disabledClassName: 'radon-select-disabled',
       currentOptionStyle: {},
-      optionListStyle: {}
+      optionListStyle: {},
+      disableUpDownAutoRefresh: false
     };
   },
   getInitialState: function getInitialState() {
@@ -129,7 +136,9 @@ var classBase = React.createClass({
       selectedOptionIndex: selectedOptionIndex,
       selectedOptionVal: this.props.children[selectedOptionIndex].props.value
     }, function () {
-      this.onChange();
+      if (!this.props.disableUpDownAutoRefresh) {
+        this.onChange();
+      }
 
       if (this.state.open) {
         this.isFocusing = true;
@@ -337,6 +346,9 @@ var classBase = React.createClass({
     var hiddenListStyle = { visibility: 'hidden' };
     var selectedOptionContent = this.state.selectedOptionIndex !== false && this.props.children[this.state.selectedOptionIndex].props.children;
 
+    var optionLabel = this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName;
+    var ariaLabel = generateAriaLabel(optionLabel, this.state.selectedOptionVal);
+
     if (this.props.optionListStyle) {
       hiddenListStyle = assign({}, this.props.optionListStyle, hiddenListStyle);
     }
@@ -360,6 +372,7 @@ var classBase = React.createClass({
           onBlur: this.onBlur,
           onClick: this.toggleOpen,
           'aria-expanded': this.state.open,
+          'aria-label': ariaLabel,
           style: this.props.currentOptionStyle },
         selectedOptionContent || this.props.placeholderText || this.props.children[0].props.children
       ) : '',
@@ -376,7 +389,7 @@ var classBase = React.createClass({
           value: this.state.selectedOptionVal,
           className: this.props.hiddenSelectClassName,
           tabIndex: -1,
-          'aria-label': this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName,
+          'aria-label': ariaLabel,
           'aria-hidden': true },
         React.Children.map(this.props.children, function (child, index) {
           return React.createElement(
@@ -442,6 +455,8 @@ classBase.Option = React.createClass({
     });
   },
   render: function render() {
+    var optionLabel = this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName;
+    var ariaLabel = generateAriaLabel(optionLabel, this.props.value);
     return (
       // Safari ignores tabindex on buttons, and Firefox ignores tabindex on anchors
       // use a <div role="button">.
@@ -449,6 +464,7 @@ classBase.Option = React.createClass({
         'div',
         {
           role: 'button',
+          'aria-label': ariaLabel,
           className: this.getClassNames(),
           'data-automation-id': this.props.automationId,
           tabIndex: -1,

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -12,6 +12,11 @@ var keyboard = {
   downArrow: 40
 };
 
+// Nessesary as div(role=button) does not report value or aria-valuetext to the screenreader
+var generateAriaLabel = function (label, value) {
+  return `${label} ${value}`;
+};
+
 var doesOptionMatch = function (option, s) {
   s = s.toLowerCase();
 
@@ -346,6 +351,9 @@ var classBase = React.createClass({
     var selectedOptionContent = this.state.selectedOptionIndex !== false &&
       this.props.children[this.state.selectedOptionIndex].props.children;
 
+    var optionLabel = this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName;
+    var ariaLabel = generateAriaLabel(optionLabel, this.state.selectedOptionVal);
+
     if (this.props.optionListStyle) {
       hiddenListStyle = assign({}, this.props.optionListStyle, hiddenListStyle);
     }
@@ -367,6 +375,7 @@ var classBase = React.createClass({
             onBlur={this.onBlur}
             onClick={this.toggleOpen}
             aria-expanded={this.state.open}
+            aria-label={ariaLabel}
             style={this.props.currentOptionStyle}>
             {selectedOptionContent || this.props.placeholderText || this.props.children[0].props.children}
           </div>
@@ -385,7 +394,7 @@ var classBase = React.createClass({
           value={this.state.selectedOptionVal}
           className={this.props.hiddenSelectClassName}
           tabIndex={-1}
-          aria-label={this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName }
+          aria-label={ariaLabel}
           aria-hidden={true} >
             {React.Children.map(this.props.children, function (child, index) {
               return <option key={index} value={child.props.value}>{child.props.value}</option>
@@ -444,11 +453,14 @@ classBase.Option = React.createClass({
     });
   },
   render () {
+    var optionLabel = this.props.ariaLabel ? this.props.ariaLabel : this.props.selectName;
+    var ariaLabel = generateAriaLabel(optionLabel, this.props.value);
     return (
       // Safari ignores tabindex on buttons, and Firefox ignores tabindex on anchors
       // use a <div role="button">.
       <div
         role='button'
+        aria-label={ariaLabel}
         className={this.getClassNames()}
         data-automation-id={this.props.automationId}
         tabIndex={-1}


### PR DESCRIPTION
# Overview
This fixes 2 things
1. The currently selected value did not have `aria-text` applied to it
2. Because the select is made up of `div(role=button)` aria was not picking up on the value property

This lead to the solution of dynamic aria-labels that have the label and the value included

# Review Notes
1. the `lib/select.js` file in this pr has some code that wasn't transpiled from the last merge