### PR TITLE
Add Aria-Expanded attr to expanded wrapper div

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -56,7 +56,8 @@ var classBase = React.createClass({
     currentOptionClassName: React.PropTypes.string,
     hiddenSelectClassName: React.PropTypes.string,
     currentOptionStyle: React.PropTypes.object,
-    optionListStyle: React.PropTypes.object
+    optionListStyle: React.PropTypes.object,
+    disableUpDownAutoRefresh: React.PropTypes.bool
   },
   getDefaultProps: function getDefaultProps() {
     return {
@@ -73,7 +74,8 @@ var classBase = React.createClass({
       hiddenSelectClassName: 'radon-select-hidden-select',
       disabledClassName: 'radon-select-disabled',
       currentOptionStyle: {},
-      optionListStyle: {}
+      optionListStyle: {},
+      disableUpDownAutoRefresh: false
     };
   },
   getInitialState: function getInitialState() {
@@ -129,7 +131,9 @@ var classBase = React.createClass({
       selectedOptionIndex: selectedOptionIndex,
       selectedOptionVal: this.props.children[selectedOptionIndex].props.value
     }, function () {
-      this.onChange();
+      if (!this.props.disableUpDownAutoRefresh) {
+        this.onChange();
+      }
 
       if (this.state.open) {
         this.isFocusing = true;
@@ -257,7 +261,9 @@ var classBase = React.createClass({
     var child = this.refs['option' + index];
 
     // Null safety here prevents an iOS-specific bug preventing selection of options
-    ev ? ev.preventDefault() : null;
+    if (ev) {
+      ev.preventDefault();
+    }
 
     this.setState({
       selectedOptionIndex: index,
@@ -365,7 +371,11 @@ var classBase = React.createClass({
       ) : '',
       this.state.open ? React.createElement(
         'div',
-        { className: this.props.listClassName, onBlur: this.onBlurOption, style: this.props.optionListStyle },
+        {
+          'aria-expanded': this.state.open,
+          className: this.props.listClassName,
+          onBlur: this.onBlurOption,
+          style: this.props.optionListStyle },
         React.Children.map(this.props.children, this.renderChild)
       ) : '',
       React.createElement(

--- a/src/select.jsx
+++ b/src/select.jsx
@@ -265,7 +265,7 @@ var classBase = React.createClass({
     var child = this.refs['option' + index];
 
     // Null safety here prevents an iOS-specific bug preventing selection of options
-    ev ? ev.preventDefault() : null;
+    if (ev) { ev.preventDefault() }
 
     this.setState({
       selectedOptionIndex: index,
@@ -317,7 +317,7 @@ var classBase = React.createClass({
 
     return wrapperClassNames.join(' ');
   },
-  focus(ref) {
+  focus (ref) {
     ReactDOM.findDOMNode(ref).focus();
   },
   renderChild (child, index) {
@@ -374,7 +374,11 @@ var classBase = React.createClass({
           ''
         }
         {this.state.open ?
-          <div className={this.props.listClassName} onBlur={this.onBlurOption} style={this.props.optionListStyle}>
+          <div
+            aria-expanded={this.state.open}
+            className={this.props.listClassName}
+            onBlur={this.onBlurOption}
+            style={this.props.optionListStyle}>
             {React.Children.map(this.props.children, this.renderChild)}
           </div>
           : ''


### PR DESCRIPTION
#### Overview
- Adds an `aria-expanded` html attr to the wrapper div for the expanded select box state.
- I also fixed two minor, previously existing code-style errors that were reported when linting.

#### Notes
- The `lib/select.js` file in this PR contains code that wasn't previously transpiled from merged PR https://github.com/FormidableLabs/radon-select/pull/43.